### PR TITLE
3B-G11-W002-PR01. Limiting Date Pickers to Current Date

### DIFF
--- a/src/app/attendance/page.tsx
+++ b/src/app/attendance/page.tsx
@@ -651,7 +651,14 @@ export default function AttendancePage() {
               type="date"
               className="w-auto h-9"
               value={filterDate}
-              onChange={(e) => setFilterDate(e.target.value)}
+              max={format(new Date(), 'yyyy-MM-dd')}
+              onChange={(e) => {
+                const selected = e.target.value;
+                const today = format(new Date(), 'yyyy-MM-dd');
+
+              if (selected > today) return;
+              setFilterDate(selected);
+              }}
             />
             {activeScannedUserId && (
               <Button

--- a/src/app/attendance/page.tsx
+++ b/src/app/attendance/page.tsx
@@ -435,6 +435,16 @@ export default function AttendancePage() {
     setRecentRecords(results.flat());
   }, [filterDate]);
 
+  const onDateChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = e.target.value;
+    const today = format(new Date(), 'yyyy-MM-dd');
+
+    if (selected > today) return;
+
+    setFilterDate(selected);
+  }, []);
+
+
   useEffect(() => {
     const timerId = globalThis.setTimeout(() => {
       void loadAttendance(true, activeScannedUserId);
@@ -652,13 +662,7 @@ export default function AttendancePage() {
               className="w-auto h-9"
               value={filterDate}
               max={format(new Date(), 'yyyy-MM-dd')}
-              onChange={(e) => {
-                const selected = e.target.value;
-                const today = format(new Date(), 'yyyy-MM-dd');
-
-              if (selected > today) return;
-              setFilterDate(selected);
-              }}
+              onChange={onDateChange}
             />
             {activeScannedUserId && (
               <Button


### PR DESCRIPTION
##Summary
This change restricts the date picker to prevent selecting future dates.
It ensures users can only view attendance records for the current day and past dates, improving data accuracy and preventing invalid queries.

##Changes
Added max attribute to the date input to block future dates
Updated onChange handler to ignore manually entered future dates
Ensured compatibility with existing attendance filtering logic

##Checklist
- [x] Code follows project guidelines.
- [x] Tested locally and works as expected.
- [x] No breaking changes to existing features.